### PR TITLE
57 guard against broke files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         - CONDA_DEPS='stsci coverage'
         - CONDA_DOC_DEPS="$CONDA_DEPS sphinx"
         - SETUP_CMD='test'
-        - COSMO_CONFIG='./tests/cosmoconfig_test.yaml'
+        - COSMO_CONFIG='/home/travis/build/spacetelescope/cosmo/tests/cosmoconfig_test.yaml'
 
 install:
     # USE UTF8 ENCODING. SHOULD BE DEFAULT, BUT THIS IS INSURANCE AGAINST FUTURE CHANGES

--- a/cosmo/filesystem.py
+++ b/cosmo/filesystem.py
@@ -30,15 +30,14 @@ class FileDataFinder:
         self.data_keywords = data_keywords
         self.data_extensions = data_extensions
         self.exptype = exptype
-
-        cosmo_layout = cosmo_layout
+        self.cosmo_layout = cosmo_layout
 
         # Find data files
-        self.files = self.find_files(self.search_pattern, self.source, cosmo_layout=cosmo_layout)
+        self.files = self.find_files(self.search_pattern, self.source, cosmo_layout=self.cosmo_layout)
 
         # Check that all keywords/extensions have corresponding extensions/keywords and that they're the same length
         if len(self.header_keywords) != len(self.header_extensions):
-            raise ValueError('header_keywords and header_extensions must be the same lenght.')
+            raise ValueError('header_keywords and header_extensions must be the same length.')
 
         if bool(self.spt_keywords or self.spt_extensions):
             if not(self.spt_keywords and self.spt_extensions):

--- a/cosmo/filesystem.py
+++ b/cosmo/filesystem.py
@@ -115,7 +115,7 @@ class FileData:
         self.data_exts = data_exts
         self.spt_suffix = spt_suffix
         self.spt_file = self._create_spt_filename()
-        self.data = {}
+        self.data = {'FILENAME': self.filename}
 
     def _create_spt_filename(self) -> Union[str, None]:
         """Create an spt filename based on the input filename."""

--- a/cosmo/sms/ingest_sms.py
+++ b/cosmo/sms/ingest_sms.py
@@ -71,9 +71,10 @@ class SMSFile:
         """Initialize and ingest the sms file data."""
         self.datetime_format = '%Y-%m-%d %H:%M:%S'
         self.filename = smsfile
-        self._data = self.ingest_smsfile()
-        self.data = pd.DataFrame(self._data).astype(self.table_keys)
         self.ingest_date = datetime.datetime.today()
+
+        self._data = self.ingest_smsfile()
+        self.data: pd.DataFrame = pd.DataFrame(self._data).astype(self.table_keys)
 
     @property
     def single_value_patterns(self) -> dict:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -10,7 +10,7 @@ TEST_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/')
 TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
 
 # Check to make sure that the test config file is being used. If not, don't run the tests
-if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
+if os.path.abspath(os.environ['COSMO_CONFIG']) != TEST_CONFIG:
     raise TypeError('Tests should only be executed with the testing configuration file')
 
 ARGS = (

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -7,6 +7,11 @@ from astropy.io import fits
 from cosmo.filesystem import get_file_data, FileData, FileDataFinder
 
 TEST_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/')
+TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
+
+# Check to make sure that the test config file is being used. If not, don't run the tests
+if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
+    raise TypeError('Tests should only be executed with the testing configuration file')
 
 ARGS = (
     'source_dr',

--- a/tests/test_osm_data_models.py
+++ b/tests/test_osm_data_models.py
@@ -6,6 +6,11 @@ from cosmo.monitors.osm_data_models import OSMShiftDataModel
 
 
 TEST_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/')
+TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
+
+# Check to make sure that the test config file is being used. If not, don't run the tests
+if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
+    raise TypeError('Tests should only be executed with the testing configuration file')
 
 
 class TestOSMDataModel:

--- a/tests/test_osmshift_monitors.py
+++ b/tests/test_osmshift_monitors.py
@@ -8,6 +8,11 @@ from cosmo.monitors.osm_shift_monitors import (
 from cosmo.monitors.osm_data_models import OSMShiftDataModel
 
 TEST_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/')
+TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
+
+# Check to make sure that the test config file is being used. If not, don't run the tests
+if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
+    raise TypeError('Tests should only be executed with the testing configuration file')
 
 # TODO: Need to define a better test data set that includes everything that we need: Both FUV segments, NUV Data,
 #  all acq types etc class

--- a/tests/test_sms_ingest.py
+++ b/tests/test_sms_ingest.py
@@ -3,9 +3,13 @@ import os
 
 from cosmo.sms import SMSFinder, SMSFile, SMSFileStats, SMSTable, ingest_sms_data, DB
 
-# TODO: Set up a test database to use during these tests
 TEST_DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data/')
 TEST_DB = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test.db')
+TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
+
+# Check to make sure that the test config file is being used. If not, don't run the tests
+if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
+    raise TypeError('Tests should only be executed with the testing configuration file')
 
 SMSFinder_BAD_PATHS = (
     ('source',),
@@ -22,7 +26,6 @@ SMSFile_GOOD_DATA = (
         (os.path.join(TEST_DATA, test_file),) for test_file in ['111078a6.txt', '180147b1.txt', '180148a5.l-exp']
     ]
 )
-
 
 class TestIngestSmsData:
 


### PR DESCRIPTION
I thought about it and decided to allow an error to be raised if a broken file is encountered.

Additionally, this pull request adds a guard against using a config file that isn't the testing config file included with the package. I also added the filename to the data recovered from the `filesystem` module. 

Resolves #57 