### PR TITLE
Remove example monitors; update v2v3; update peakd; update peakxd

### DIFF
--- a/cosmo/monitors/acq_data_models.py
+++ b/cosmo/monitors/acq_data_models.py
@@ -44,7 +44,8 @@ class AcqPeakdModel(BaseDataModel):
 
     def get_new_data(self):
         # ACQ file header keys, extensions
-        acq_keywords, acq_extensions = ('ACQSLEWX', 'EXPSTART', 'LIFE_ADJ', 'ROOTNAME', 'PROPOSID'), (0, 1, 0, 0, 0)
+        acq_keywords = ('ACQSLEWX', 'EXPSTART', 'LIFE_ADJ', 'ROOTNAME', 'PROPOSID', 'OPT_ELEM', 'CENWAVE')
+        acq_extensions = (0, 1, 0, 0, 0, 0, 0)
 
         # SPT file header keys, extensions
         spt_keywords, spt_extensions = ('DGESTAR',), (0,)
@@ -70,7 +71,8 @@ class AcqPeakxdModel(BaseDataModel):
 
     def get_new_data(self):
         # ACQ file header keys, extensions
-        acq_keywords, acq_extensions = ('ACQSLEWY', 'EXPSTART', 'LIFE_ADJ', 'ROOTNAME', 'PROPOSID'), (0, 1, 0, 0, 0)
+        acq_keywords = ('ACQSLEWY', 'EXPSTART', 'LIFE_ADJ', 'ROOTNAME', 'PROPOSID', 'OPT_ELEM', 'CENWAVE')
+        acq_extensions = (0, 1, 0, 0, 0, 0, 0)
 
         # SPT file header keys, extensions
         spt_keywords, spt_extensions = ('DGESTAR',), (0,)


### PR DESCRIPTION
This PR resolves #96  and resolves #71 

All example monitors have been removed.

For the V2V3 monitor, tracking and notifications have been implemented. 

For the spectroscopic ACQ monitors, colors were updated per LP, scatter plots were refactored to be grouped by FGS with the addition of an "All FGS" option, and additional information was added to the hover labels. For PEAKXD, a vertical line was added at the time of the activation of the new algorithm. 