### PR TITLE
97 update drift monitors

### DIFF
--- a/cosmo/monitors/osm_data_models.py
+++ b/cosmo/monitors/osm_data_models.py
@@ -54,6 +54,11 @@ class OSMDriftDataModel(BaseDataModel):
         # Get lampflash data from the files
         file_data = pd.DataFrame(get_lampflash_data(self.files_source, self.cosmo_layout))
 
+        # Remove any rows that have empty data columns
+        file_data = file_data.drop(
+            file_data[file_data.apply(lambda x: not bool(len(x.SHIFT_DISP)), axis=1)].index.values
+        ).reset_index(drop=True)
+
         # Grab data from the SMSTable.
         sms_data = pd.DataFrame(
             list(

--- a/cosmo/monitors/osm_drift_monitors.py
+++ b/cosmo/monitors/osm_drift_monitors.py
@@ -1,5 +1,6 @@
 import plotly.graph_objs as go
 
+from astropy.time import Time
 from monitorframe.monitor import BaseMonitor
 
 from .osm_data_models import OSMDriftDataModel
@@ -9,67 +10,60 @@ from .. import SETTINGS
 COS_MONITORING = SETTINGS['output']
 
 
-class OSMDriftMonitor(BaseMonitor):
-    """Baseclass for the FUV and NUV Drift Monitor. This class is a partial implementation and is intended to be
-    inherited.
-    """
-    data_model = OSMDriftDataModel
-    output = COS_MONITORING
-    labels = ['ROOTNAME', 'LIFE_ADJ', 'FPPOS', 'PROPOSID', 'OPT_ELEM']
+def get_osmdrift_data(data, detector):
+    """Get OSM Drift monitoring data."""
+    df = data[data.DETECTOR == detector].reset_index(drop=True)
 
-    detector = None
-    subplots = True  # Both monitors will have subplots. The number and organization will depend on the detector.
+    # Calculate the relative shift (relative to the first shift measurement for each set of flashes) for AD and XD
+    df['REL_SHIFT_DISP'] = df.apply(lambda x: x.SHIFT_DISP[1:] - x.SHIFT_DISP[0], axis=1)
+    df['REL_SHIFT_XDISP'] = df.apply(lambda x: x.SHIFT_XDISP[1:] - x.SHIFT_XDISP[0], axis=1)
 
-    def get_data(self):
-        return self.model.new_data[self.model.new_data.DETECTOR == self.detector].reset_index(drop=True)
+    # Drop the first value for the other data columns
+    for col in ['TIME', 'SHIFT_DISP', 'SHIFT_XDISP', 'SEGMENT']:
+        df[col] = df.apply(lambda x: x[col][1:], axis=1)
 
-    def track(self):
-        """Track the drift for Shift1 and Shift2."""
-        # Calculate the relative shift (relative to the first shift measurement for each set of flashes) for AD and XD
-        self.data['REL_SHIFT_DISP'] = self.data.apply(
-            lambda x: x.SHIFT_DISP - x.SHIFT_DISP[0] if len(x.SHIFT_DISP) else x.SHIFT_DISP, axis=1
-        )
+    # Expand the dataframe
+    exploded = explode_df(
+        df, ['TIME', 'SHIFT_DISP', 'SHIFT_XDISP', 'SEGMENT', 'REL_SHIFT_DISP', 'REL_SHIFT_XDISP']
+    )
 
-        self.data['REL_SHIFT_XDISP'] = self.data.apply(
-            lambda x: x.SHIFT_XDISP - x.SHIFT_XDISP[0] if len(x.SHIFT_XDISP) else x.SHIFT_XDISP, axis=1
-        )
+    # Add drift columns and time since OSM move columns
+    exploded = exploded.assign(
+        SHIFT1_DRIFT=lambda x: x.REL_SHIFT_DISP / x.TIME,
+        SHIFT2_DRIFT=lambda x: x.REL_SHIFT_XDISP / x.TIME,
+        REL_TSINCEOSM1=lambda x: x.TIME + x.TSINCEOSM1,
+        REL_TSINCEOSM2=lambda x: x.TIME + x.TSINCEOSM2,
+    )
 
-        # Expand the dataframe
-        exploded = explode_df(
-            self.data, ['TIME', 'SHIFT_DISP', 'SHIFT_XDISP', 'SEGMENT', 'REL_SHIFT_DISP', 'REL_SHIFT_XDISP']
-        )
-
-        # Add drift columns and time since OSM move columns
-        exploded = exploded.assign(
-            SHIFT1_DRIFT=lambda x: x.REL_SHIFT_DISP / x.TIME,
-            SHIFT2_DRIFT=lambda x: x.REL_SHIFT_XDISP / x.TIME,
-            REL_TSINCEOSM1=lambda x: x.TIME + x.TSINCEOSM1,
-            REL_TSINCEOSM2=lambda x: x.TIME + x.TSINCEOSM2,
-        )
-
-        # Add SEGMENT to the hover text
-        exploded.hover_text = exploded.apply(lambda x: f'{x.SEGMENT}<br>' + x.hover_text, axis=1)
-
-        return exploded
-
-    def filter_data(self):
-        """Filter data on detector."""
-        return self.data[self.data.DETECTOR == self.detector].reset_index(drop=True)
-
-    def store_results(self):
-        # TODO: define what to store and how
-        pass
+    return exploded
 
 
-class FUVOSMDriftMonitor(OSMDriftMonitor):
+class FUVOSMDriftMonitor(BaseMonitor):
     """FUV OSM Drift monitor. Includes the drift for both along and cross-dispersion directions as a function of time
     since the last OSM1 move.
     """
-    detector = 'FUV'
+    data_model = OSMDriftDataModel
+    output = COS_MONITORING
+    labels = ['ROOTNAME', 'LIFE_ADJ', 'FPPOS', 'PROPOSID', 'OPT_ELEM', 'SEGMENT']
+
+    subplots = True
     subplot_layout = (2, 1)  # 2 rows, 1 column
     # This is the format of your plot grid:
     # [ (1,1)  x1,y1 ]
     # [ (2,1) x2,y2 ]
+
+    def get_data(self):
+        return get_osmdrift_data(self.model.new_data, 'FUV')
+
+    def track(self):
+        """Track statistics for the drift for SHIFT1 and SHIFT2 for each LP."""
+        lp_groups = self.data.groupby('LIFE_ADJ')
+        lp_stats = {
+            'SHIFT1_DRIFT': lp_groups.SHIFT1_DRIFT.describe(),
+            'SHIFT2_DRIFT': lp_groups.SHIFT2_DRIFT.describe()
+        }
+
+        return lp_groups, lp_stats
 
     def plot(self):
         """Plot the Drift rate (from SHIFT1 and SHIFT2) as a function of the time since the last OSM1 move."""
@@ -78,19 +72,21 @@ class FUVOSMDriftMonitor(OSMDriftMonitor):
         titles = ['OSM1 SHIFT1', 'OSM1 SHIFT2']
 
         # Set the min and max for the scale so that each plot is plotted on the same scale
-        c_min = self.results.EXPSTART.min()
-        c_max = self.results.EXPSTART.max()
+        c_min = self.data.EXPSTART.min()
+        c_max = self.data.EXPSTART.max()
+
+        lp_groups, _ = self.results
 
         # Plot drift v time per grating
-        for grating, group in self.results.groupby('OPT_ELEM'):
+        for lp, group in lp_groups:
             for y, name, axes in zip(y_names, titles, locations):
                 trace = go.Scattergl(
                     x=group.REL_TSINCEOSM1,
                     y=group[y],
                     mode='markers',
-                    name=f'{grating} {name}',
+                    name=f'LP{lp} {name}',
                     text=group.hover_text,
-                    legendgroup=grating,
+                    legendgroup=lp,
                     marker=dict(
                         color=group.EXPSTART,
                         cmin=c_min,
@@ -98,8 +94,18 @@ class FUVOSMDriftMonitor(OSMDriftMonitor):
                         colorscale='Viridis',
                         showscale=True,
                         colorbar=dict(
-                            len=0.65,
-                            title='EXPSTART [mjd]'
+                            title='Observation Date',
+                            tickmode='array',
+                            ticks='outside',
+                            tickvals=[self.data.EXPSTART.min(), self.data.EXPSTART.mean(), self.data.EXPSTART.max()],
+                            ticktext=[
+                                f'{Time(self.data.EXPSTART.min(), format="mjd").to_datetime().date()}',
+                                f'{Time(self.data.EXPSTART.mean(), format="mjd").to_datetime().date()}',
+                                f'{Time(self.data.EXPSTART.max(), format="mjd").to_datetime().date()}'
+                            ],
+                            len=0.7,
+                            y=0,
+                            yanchor='bottom'
                         ),
                     ),
                 )
@@ -108,7 +114,7 @@ class FUVOSMDriftMonitor(OSMDriftMonitor):
 
         # Set the layout.
         layout = go.Layout(
-            title=f'{self.detector} {self.name}',
+            title=self.name,
             xaxis=dict(title='Time since last OSM1 move [s]'),
             xaxis2=dict(title='Time since last OSM1 move [s]'),
             yaxis=dict(title='SHIFT1 drift rate [pixels/sec]'),
@@ -117,13 +123,34 @@ class FUVOSMDriftMonitor(OSMDriftMonitor):
 
         self.figure.update_layout(layout)
 
+    def store_results(self):
+        # This will be implemented with the database backend.
+        pass
 
-class NUVOSMDriftMonitor(OSMDriftMonitor):
-    detector = 'NUV'
+
+class NUVOSMDriftMonitor(BaseMonitor):
+    data_model = OSMDriftDataModel
+    output = COS_MONITORING
+    labels = ['ROOTNAME', 'LIFE_ADJ', 'FPPOS', 'PROPOSID', 'OPT_ELEM']
+
+    subplots = True
     subplot_layout = (2, 2)
     # This is the format of your plot grid:
     # [ (1,1) x1,y1 ]  [ (1,2) x2,y2 ]
     # [ (2,1) x3,y3 ]  [ (2,2) x4,y4 ]  The axes labels and x/y combinations need to match this layout.
+
+    def get_data(self):
+        return get_osmdrift_data(self.model.new_data, 'NUV')
+
+    def track(self):
+        """Track SHIFT1 and SHIFT2 statistics per SEGMENT (stripe for NUV)."""
+        segment_groups = self.data.groupby('SEGMENT')
+        segment_stats = {
+            'SHIFT1_DRIFT': segment_groups.SHIFT1_DRIFT.describe(),
+            'SHIFT2_DRIFT': segment_groups.SHIFT2_DRIFT.describe()
+        }
+
+        return segment_groups, segment_stats
 
     def plot(self):
         """Plot drift rate (from SHIFT1 and SHIFT2) as a function of time since the last OSM1 move and the time since
@@ -136,30 +163,29 @@ class NUVOSMDriftMonitor(OSMDriftMonitor):
         locations = [(1, 1), (2, 1), (1, 2), (2, 2)]
 
         # Set the min and max for the scale so that each plot is plotted on the same scale
-        c_min = self.results.EXPSTART.min()
-        c_max = self.results.EXPSTART.max()
+        c_min = self.data.DATETIME_START.min()
+        c_max = self.data.DATETIME_START.max()
+
+        segment_groups, _ = self.results
 
         # Plot drift v time for each grating
-        for grating, group in self.results.groupby('OPT_ELEM'):
+        for segment, group in segment_groups:
             for x, y, axes, name in zip(x_names, y_names, locations, titles):
                 trace = go.Scattergl(
                     x=group[x],
                     y=group[y],
                     mode='markers',
                     text=group.hover_text,
-                    name=f'{grating} {name}',
-                    legendgroup=grating,
+                    name=f'{segment} {name}',
+                    legendgroup=segment,
                     marker=dict(
-                        color=group.EXPSTART,
+                        color=group.DATETIME_START,
                         cmin=c_min,
                         cmax=c_max,
                         colorscale='Viridis',
                         showscale=True,
                         colorbar=dict(  # TODO: Move the colorbar location down
-                            len=0.65,
-                            y=0,
-                            yanchor='bottom',
-                            title='EXPSTART [mjd]'
+                            title='Date of Observation'
                         )
                     ),
                 )
@@ -168,7 +194,7 @@ class NUVOSMDriftMonitor(OSMDriftMonitor):
 
         # Set the layout. Refer to the commented plot grid to make sense of this.
         layout = go.Layout(
-            title=f'{self.detector} {self.name}',
+            title=self.name,
             xaxis=dict(title='Time since last OSM1 move [s]'),
             xaxis3=dict(title='Time since last OSM1 move [s]'),
             xaxis2=dict(title='Time since last OSM2 move [s]'),

--- a/cosmo/monitors/osm_drift_monitors.py
+++ b/cosmo/monitors/osm_drift_monitors.py
@@ -103,7 +103,7 @@ class FUVOSMDriftMonitor(BaseMonitor):
                                 f'{Time(self.data.EXPSTART.mean(), format="mjd").to_datetime().date()}',
                                 f'{Time(self.data.EXPSTART.max(), format="mjd").to_datetime().date()}'
                             ],
-                            len=0.7,
+                            len=0.6,
                             y=0,
                             yanchor='bottom'
                         ),
@@ -115,7 +115,7 @@ class FUVOSMDriftMonitor(BaseMonitor):
         # Set the layout.
         layout = go.Layout(
             title=self.name,
-            xaxis=dict(title='Time since last OSM1 move [s]'),
+            xaxis=dict(title='Time since last OSM1 move [s]', matches='x2'),
             xaxis2=dict(title='Time since last OSM1 move [s]'),
             yaxis=dict(title='SHIFT1 drift rate [pixels/sec]'),
             yaxis2=dict(title='SHIFT2 drift rate [pixels/sec]')
@@ -163,8 +163,8 @@ class NUVOSMDriftMonitor(BaseMonitor):
         locations = [(1, 1), (2, 1), (1, 2), (2, 2)]
 
         # Set the min and max for the scale so that each plot is plotted on the same scale
-        c_min = self.data.DATETIME_START.min()
-        c_max = self.data.DATETIME_START.max()
+        c_min = self.data.EXPSTART.min()
+        c_max = self.data.EXPSTART.max()
 
         segment_groups, _ = self.results
 
@@ -179,13 +179,24 @@ class NUVOSMDriftMonitor(BaseMonitor):
                     name=f'{segment} {name}',
                     legendgroup=segment,
                     marker=dict(
-                        color=group.DATETIME_START,
+                        color=group.EXPSTART,
                         cmin=c_min,
                         cmax=c_max,
                         colorscale='Viridis',
                         showscale=True,
-                        colorbar=dict(  # TODO: Move the colorbar location down
-                            title='Date of Observation'
+                        colorbar=dict(
+                            title='Observation Date',
+                            tickmode='array',
+                            ticks='outside',
+                            tickvals=[self.data.EXPSTART.min(), self.data.EXPSTART.mean(), self.data.EXPSTART.max()],
+                            ticktext=[
+                                f'{Time(self.data.EXPSTART.min(), format="mjd").to_datetime().date()}',
+                                f'{Time(self.data.EXPSTART.mean(), format="mjd").to_datetime().date()}',
+                                f'{Time(self.data.EXPSTART.max(), format="mjd").to_datetime().date()}'
+                            ],
+                            len=0.55,
+                            y=0,
+                            yanchor='bottom'
                         )
                     ),
                 )
@@ -195,9 +206,9 @@ class NUVOSMDriftMonitor(BaseMonitor):
         # Set the layout. Refer to the commented plot grid to make sense of this.
         layout = go.Layout(
             title=self.name,
-            xaxis=dict(title='Time since last OSM1 move [s]'),
+            xaxis=dict(title='Time since last OSM1 move [s]', matches='x3'),
             xaxis3=dict(title='Time since last OSM1 move [s]'),
-            xaxis2=dict(title='Time since last OSM2 move [s]'),
+            xaxis2=dict(title='Time since last OSM2 move [s]', matches='x4'),
             xaxis4=dict(title='Time since last OSM2 move [s]'),
             yaxis=dict(title='SHIFT1 drift rate [pixels/sec]'),
             yaxis3=dict(title='SHIFT2 drift rate [pixels/sec]'),
@@ -206,3 +217,6 @@ class NUVOSMDriftMonitor(BaseMonitor):
         )
 
         self.figure.update_layout(layout)
+
+    def store_results(self):
+        pass


### PR DESCRIPTION
Resolves #97 

This PR includes a refactor of the OSM Drift monitors in general as well as updates. 

FUV: 
- grouped by lifetime position
- colorbar shows date rather than EXPSTART
- track drift statistics per lifetime position

NUV: 
- grouped by stripe
- track drift statistics per stripe