### PR TITLE
Add initial general acqimage monitor

### DIFF
--- a/cosmo/monitors/acq_data_models.py
+++ b/cosmo/monitors/acq_data_models.py
@@ -10,9 +10,9 @@ FILES_SOURCE = SETTINGS['filesystem']['source']
 
 
 def dgestar_to_fgs(results: List[dict]) -> None:
-    """Add a dom_fgs key to each row dictionary."""
+    """Add a FGS key to each row dictionary."""
     for item in results:
-        item.update({'dom_fgs': item['DGESTAR'][-2:]})  # The dominant guide star key is the last 2 values in the string
+        item.update({'FGS': item['DGESTAR'][-2:]})  # The dominant guide star key is the last 2 values in the string
 
 
 def get_acq_data(data_dir: str, acq_keys: tuple, acq_extensions: tuple, spt_keys: tuple, spt_extensions: tuple,

--- a/cosmo/monitors/acq_data_models.py
+++ b/cosmo/monitors/acq_data_models.py
@@ -112,9 +112,10 @@ class AcqImageModel(BaseDataModel):
         # ACQ keys, extensions
         acq_keywords = (
             'ACQSLEWX', 'ACQSLEWY', 'EXPSTART', 'ROOTNAME', 'PROPOSID', 'OBSTYPE', 'NEVENTS', 'SHUTTER', 'LAMPEVNT',
-            'ACQSTAT', 'EXTENDED', 'LINENUM'
+            'ACQSTAT', 'EXTENDED', 'LINENUM', 'APERTURE', 'OPT_ELEM'
         )
-        acq_extensions = (0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0)
+
+        acq_extensions = (0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0)
 
         # SPT keys, extensions
         spt_keywords, spt_extensions = ('DGESTAR',), (0,)

--- a/cosmo/monitors/acq_monitors.py
+++ b/cosmo/monitors/acq_monitors.py
@@ -16,7 +16,7 @@ COS_MONITORING = SETTINGS['output']
 
 class AcqImageMonitor(BaseMonitor):
     data_model = AcqImageModel
-    labels = ['ROOTNAME', 'PROPOSID']
+    labels = ['ROOTNAME', 'PROPOSID', 'FGS']
     output = COS_MONITORING
 
     def get_data(self):
@@ -141,7 +141,7 @@ class AcqImageV2V3Monitor(BaseMonitor):
 
     def track(self):
         """Track the fit and fit-line for the period since the last FGS alignment."""
-        groups = self.data.groupby('dom_fgs')
+        groups = self.data.groupby('FGS')
 
         last_updated_results = {}
         for name, group in groups:
@@ -428,7 +428,7 @@ class SpecAcqBaseMonitor(BaseMonitor):
 
     def track(self):
         """Track the standard deviation of the slew per FGS."""
-        groups = self.data.groupby('dom_fgs')
+        groups = self.data.groupby('FGS')
         scatter = groups[self.slew].std()
 
         return groups, scatter


### PR DESCRIPTION
This PR adds a general ACQIMAGE monitor. 

Initial configuration: 

- tracks: slew/offset distance
- outliers: offset >= 2 arcseconds, ACQSTAT = 'Failure', SHUTTER = 'Closed'
- figure: Scatter plot of ACQSLEWY vs ACQSLEWX with marginal histograms, colored by EXPSTART

Resolves #99 
Resolves #105 