### PR TITLE
108 update osmdrift monitors

### DIFF
--- a/cosmo/monitor_helpers.py
+++ b/cosmo/monitor_helpers.py
@@ -2,8 +2,9 @@ import pandas as pd
 import numpy as np
 import datetime
 
+from itertools import repeat
 from astropy.time import Time, TimeDelta
-from typing import Union, Iterable, Tuple, Sequence
+from typing import Union, Iterable, Tuple, Sequence, List
 
 
 def convert_day_of_year(date: Union[float, str]) -> Time:
@@ -95,3 +96,16 @@ class ExposureAbsoluteTime:
         instance = cls(expstart=expstart, time_array=time_array)
 
         return instance.compute_absolute_time(time_delta_format=time_format)
+
+
+def create_visibility(trace_lengths: List[int], visible_list: List[bool]) -> List[bool]:
+    """Create visibility lists for plotly buttons. trace_lengths and visible_list must be in the correct order.
+
+    :param trace_lengths: List of the number of traces in each "button set".
+    :param visible_list: Visibility setting for each button set (either True or False).
+    """
+    visibility = []  # Total visibility. Length should match the total number of traces in the figure.
+    for visible, trace_length in zip(visible_list, trace_lengths):
+        visibility += list(repeat(visible, trace_length))  # Set each trace per button.
+
+    return visibility

--- a/cosmo/monitors/osm_drift_monitors.py
+++ b/cosmo/monitors/osm_drift_monitors.py
@@ -149,10 +149,7 @@ class FUVOSMDriftMonitor(BaseMonitor):
                     dict(
                         label=label,
                         method='update',
-                        args=[
-                            {'visible': visible},
-                            {'title': title}
-                        ]
+                        args=[{'visible': visible}, {'title': title}]
                     ) for label, title, visible in zip(labels, titles, [all_visible, lp_neg1, lp_1, lp_2, lp_3, lp_4])
                 ]
             )
@@ -160,7 +157,7 @@ class FUVOSMDriftMonitor(BaseMonitor):
 
         # Set the layout.
         layout = go.Layout(
-            title=f'<a href="https://spacetelescope.github.io/cosmo/monitors.html#osm-drift-monitor">{self.name}</a>',
+            title=f'<a href="{self.docs}">{self.name}</a>',
             xaxis=dict(title='Time since last OSM1 move [s]', matches='x2'),
             xaxis2=dict(title='Time since last OSM1 move [s]'),
             yaxis=dict(title='SHIFT1 drift rate [pixels/sec]'),
@@ -285,10 +282,7 @@ class NUVOSMDriftMonitor(BaseMonitor):
                     dict(
                         label=label,
                         method='update',
-                        args=[
-                            {'visible': visible},
-                            {'title': title}
-                        ]
+                        args=[{'visible': visible}, {'title': title}]
                     ) for label, title, visible in zip(labels, titles, [all_visible, nuva, nuvb, nuvc])
                 ]
             )
@@ -296,7 +290,7 @@ class NUVOSMDriftMonitor(BaseMonitor):
 
         # Set the layout. Refer to the commented plot grid to make sense of this.
         layout = go.Layout(
-            title=f'<a href="https://spacetelescope.github.io/cosmo/monitors.html#osm-drift-monitor">{self.name}</a>',
+            title=f'<a href="{self.docs}">{self.name}</a>',
             xaxis=dict(title='Time since last OSM1 move [s]', matches='x3'),
             xaxis3=dict(title='Time since last OSM1 move [s]'),
             xaxis2=dict(title='Time since last OSM2 move [s]', matches='x4'),

--- a/cosmo/monitors/osm_shift_monitors.py
+++ b/cosmo/monitors/osm_shift_monitors.py
@@ -5,10 +5,10 @@ import os
 
 from itertools import repeat
 from monitorframe.monitor import BaseMonitor
-from typing import List, Union
+from typing import Union
 
 from .osm_data_models import OSMShiftDataModel
-from ..monitor_helpers import ExposureAbsoluteTime, explode_df
+from ..monitor_helpers import ExposureAbsoluteTime, explode_df, create_visibility
 from .. import SETTINGS
 
 COS_MONITORING = SETTINGS['output']
@@ -22,19 +22,6 @@ LP_MOVES = {
 def match_dfs(df1: pd.DataFrame, df2: pd.DataFrame, key: str) -> pd.DataFrame:
     """Filter df1 based on which values in key are available in df2."""
     return df1[df1.apply(lambda x: x[key] in df2[key].values, axis=1)]
-
-
-def create_visibility(trace_lengths: List[int], visible_list: List[bool]) -> List[bool]:
-    """Create visibility lists for plotly buttons. trace_lengths and visible_list must be in the correct order.
-
-    :param trace_lengths: List of the number of traces in each "button set".
-    :param visible_list: Visibility setting for each button set (either True or False).
-    """
-    visibility = []  # Total visibility. Length should match the total number of traces in the figure.
-    for visible, trace_length in zip(visible_list, trace_lengths):
-        visibility += list(repeat(visible, trace_length))  # Set each trace per button.
-
-    return visibility
 
 
 def compute_segment_diff(df: pd.DataFrame, shift: str, segment1: str, segment2: str) -> Union[pd.DataFrame, None]:

--- a/tests/test_monitor_helpers.py
+++ b/tests/test_monitor_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 
-from cosmo.monitor_helpers import convert_day_of_year, fit_line, explode_df, ExposureAbsoluteTime
+from cosmo.monitor_helpers import convert_day_of_year, fit_line, explode_df, ExposureAbsoluteTime, create_visibility
 
 CONVERT_DOY_GOOD_DATES = (('date',), [(2017.301,), ('2017.301',)])
 CONVERT_DOY_BAD_DATES = (('date',), [(1,), ('1',)])
@@ -91,3 +91,15 @@ class TestAbsoluteTime:
     @pytest.mark.parametrize(*ABSTIME_GOOD_INPUT)
     def test_ingest_works(self, df, expstart, time_array, time_array_key):
         ExposureAbsoluteTime(df=df, expstart=expstart, time_array=time_array, time_array_key=time_array_key)
+
+
+class TestCreateVisibility:
+
+    def test_output(self):
+        test_trace_lengths = [1, 2, 3]
+        test_visible = [True, False, False]
+
+        visible_options = create_visibility(test_trace_lengths, test_visible)
+
+        assert len(visible_options) == 6
+        assert visible_options == [True, False, False, False, False, False]


### PR DESCRIPTION
This PR updates the OSM Drift monitors: 
    FUV: Figures are plotted per grating and grouped by LP with buttons
    NUV: Figures are plotted per grating and grouped by stripe with buttons

And also includes minor style updates,  refactoring of duplicated code in the OSM Shift monitors, and the addition of a `docs` attribute on each monitor class for the link to the documentation. 

Resolves #108 