### PR TITLE
Refactor SMS Db; Use new primary key; fix conflict conditions

### DIFF
--- a/cosmo/sms/sms_db.py
+++ b/cosmo/sms/sms_db.py
@@ -21,8 +21,10 @@ class SMSFileStats(BaseModel):
 
 class SMSTable(BaseModel):
 
-    ROOTNAME = TextField(primary_key=True)
-    FILEID = ForeignKeyField(SMSFileStats, backref='exposures', on_delete='cascade')
+    EXPOSURE = TextField(primary_key=True)
+    ROOTNAME = TextField()
+    FILEID = ForeignKeyField(SMSFileStats, field='FILEID', backref='exposures', on_delete='cascade')
+    VERSION = TextField()
     PROPOSID = IntegerField(verbose_name='proposal id')
     DETECTOR = TextField()
     OPMODE = TextField()

--- a/tests/test_sms_ingest.py
+++ b/tests/test_sms_ingest.py
@@ -76,6 +76,8 @@ class TestSMSFile:
         correct_dtypes = {
             'FILEID': object,
             'FILENAME': object,
+            'EXPOSURE': object,
+            'VERSION': object,
             'ROOTNAME': object,
             'PROPOSID': int,
             'DETECTOR': object,
@@ -145,3 +147,17 @@ class TestSMSFinder:
 
         assert len(testcase) == 1
         assert testcase.version.values[0] == 'c2'
+
+    def test_entry_is_updated(self, test_finder):
+        test_sms = SMSFile(os.path.join(TEST_DATA, '181137b3.txt'), '181137', 'b3')
+        test_sms.insert_to_db()
+
+        finder = SMSFinder(TEST_DATA)  # Will discover the new version, b4
+        finder.ingest_files()  # ingest new files
+
+        record = SMSFileStats.get(SMSFileStats.FILEID == '181137')
+        assert record.VERSION == 'c2'  # After running ingest_files the newer file should've replaced the old version
+
+        records = SMSTable.select().where(SMSTable.FILEID == '181137').dicts().iterator()
+        for record in records:
+            assert record['VERSION'] == 'c2'


### PR DESCRIPTION
This PR refactors the SMS database and adds a new field to the file ingestion. 

The new field is "EXPOSURE" which is the combination of the "PRG," "OB," and "AL" columns of the SMS files and is now the primary key for SMSTable. These values correspond to exposures as defined in the Phase II and should be more robust to changes in successive SMS versions (the previous primary key, ROOTNAME can change across SMS versions, leading to "bad" entries. Bad entries are still possible, such as when a Phase II is changed, but this happens more rarely).

A bug in the conflict resolution was also resolved. 

Resolves #109 