### PR TITLE
113 fixtures for helpers

### DIFF
--- a/cosmo/filesystem.py
+++ b/cosmo/filesystem.py
@@ -37,14 +37,14 @@ class FileDataFinder:
 
         if bool(self.spt_keywords or self.spt_extensions):
             if not(self.spt_keywords and self.spt_extensions):
-                raise TypeError('spt_keywords and spt_extensions must be used together.')
+                raise ValueError('spt_keywords and spt_extensions must be used together.')
 
             if len(self.spt_keywords) != len(self.spt_extensions):
                 raise ValueError('spt_keywords and spt_extensions must be the same length.')
 
         if bool(self.data_keywords or self.data_extensions):
             if not (self.data_keywords and self.data_extensions):
-                raise TypeError('data_keywords and data_extensions must be used together.')
+                raise ValueError('data_keywords and data_extensions must be used together.')
 
             if len(self.data_keywords) != len(self.data_extensions):
                 raise ValueError('data_keywords and data_extensions must be the same length.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,24 @@
 import os
+import pytest
 
 TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
 
 # Check to make sure that the test config file is being used. If not, don't run the tests
 if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
     raise TypeError('Tests should only be executed with the testing configuration file')
+
+
+@pytest.fixture(scope='session', autouse=True)
+def db_cleanup():
+    yield  # The tests don't actually need this test "value"
+
+    # Cleanup
+    os.remove('test.db')   # Delete test database file after the completion of all tests
+
+    # Remove temporary shared memory file if it exists
+    if os.path.exists('test.db-shm'):
+        os.remove('test.db-shm')
+
+    # Remove temporary write-ahead log file if it exists
+    if os.path.exists('test.db-wal'):
+        os.remove('test.db-wal')

--- a/tests/test_monitor_helpers.py
+++ b/tests/test_monitor_helpers.py
@@ -3,20 +3,25 @@ import pandas as pd
 
 from cosmo.monitor_helpers import convert_day_of_year, fit_line, explode_df, ExposureAbsoluteTime, create_visibility
 
-CONVERT_DOY_GOOD_DATES = (('date',), [(2017.301,), ('2017.301',)])
-CONVERT_DOY_BAD_DATES = (('date',), [(1,), ('1',)])
+
+@pytest.fixture(params=[2017.301, '2017.301'])
+def good_date(request):
+    return request.param
+
+
+@pytest.fixture(params=[1, '1'])
+def bad_date(request):
+    return request.param
 
 
 class TestConvertDayofYear:
 
-    @pytest.mark.parametrize(*CONVERT_DOY_GOOD_DATES)
-    def test_ingest(self, date):
-        convert_day_of_year(date)
+    def test_ingest(self, good_date):
+        convert_day_of_year(good_date)
 
-    @pytest.mark.parametrize(*CONVERT_DOY_BAD_DATES)
-    def test_date_type_fail(self, date):
-        with pytest.raises(ValueError):  # The format doesn't match
-            convert_day_of_year(date)
+    def test_date_type_fail(self, bad_date):
+        with pytest.raises(ValueError):  # The format shouldn't match
+            convert_day_of_year(bad_date)
 
 
 class TestFitLine:
@@ -37,60 +42,94 @@ class TestFitLine:
             fit_line(test_x, test_y)
 
 
+@pytest.fixture
+def test_df():
+    return pd.DataFrame({'a': 1, 'b': [[1, 2, 3]]})
+
+
 class TestExplodeDf:
 
-    def test_exploded_length(self):
-        test_df = pd.DataFrame({'a': 1, 'b': [[1, 2, 3]]})
+    def test_exploded_length(self, test_df):
         exploded = explode_df(test_df, ['b'])
-
         assert len(exploded) == 3
         assert all(exploded.a == 1)
 
-    def test_different_lengths_fail(self):
-        test_df = pd.DataFrame({'a': 1, 'b': [[1, 2, 3]]})
-
+    def test_different_lengths_fail(self, test_df):
         with pytest.raises(AttributeError):
-            explode_df(test_df, ['a', 'b'])
+            explode_df(test_df, ['a', 'b'])  # Column a is not "explode-able"
 
-        test_df['c'] = [[1, 2]]
+        test_df['c'] = [[1, 2]]  # Add a column with an array element of a different length than b
 
         with pytest.raises(ValueError):
             explode_df(test_df, ['c', 'b'])
 
+        # If the first column listed is longer, the procedure won't produce an error, but the result will have NaNs
+        with pytest.raises(ValueError):
+            explode_df(test_df, ['b', 'c'])
 
-ABSTIME_BAD_INPUT = (
-    ('df', 'expstart', 'time_array', 'error'),
-    [
-        (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], }), None, None, AttributeError),
-        (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], 'TIME': [1, 2, 3]}), [1, 2, 3], [1, 2, 3], ValueError),
-        (None, None, None, TypeError),
-        (pd.DataFrame({'TIME': [1, 2, 3]}), None, None, AttributeError),
-        (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], 'some_other_time': [1, 2, 3]}), None, None,
-         AttributeError),
+
+ABSTIME_BAD_INPUT = [
+    (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], }), None, None, AttributeError),
+    (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], 'TIME': [1, 2, 3]}), [1, 2, 3], [1, 2, 3], ValueError),
+    (None, None, None, TypeError),
+    (pd.DataFrame({'TIME': [1, 2, 3]}), None, None, AttributeError),
+    (
+        pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], 'some_other_time': [1, 2, 3]}),
+        None,
+        None,
+        AttributeError
+    ),
+    (None, [1, 2, 3], None, TypeError),
+    (None, None, [1, 2, 3], TypeError)
     ]
-)
 
-ABSTIME_GOOD_INPUT = (
-    ('df', 'expstart', 'time_array', 'time_array_key'),
-    [
+ABSTIME_GOOD_INPUT = [
         (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], 'TIME': [1, 2, 3]}), None, None, None),
         (pd.DataFrame({'EXPSTART': [58484.0, 58485.0, 58486.0], 'some_other_time': [1, 2, 3]}), None, None,
          'some_other_time'),
         (None, [1, 2, 3], [1, 2, 3], None)
     ]
-)
+
+
+@pytest.fixture(params=ABSTIME_BAD_INPUT)
+def bad_input(request):
+    return request.param
+
+
+@pytest.fixture(params=ABSTIME_GOOD_INPUT)
+def good_input(request):
+    return request.param
 
 
 class TestAbsoluteTime:
 
-    @pytest.mark.parametrize(*ABSTIME_BAD_INPUT)
-    def test_ingest_fails(self, df, expstart, time_array, error):
-        with pytest.raises(error):
-            ExposureAbsoluteTime(df=df, expstart=expstart, time_array=time_array)
+    def test_ingest_fails(self, bad_input):
+        df, expstart, time, error = bad_input
 
-    @pytest.mark.parametrize(*ABSTIME_GOOD_INPUT)
-    def test_ingest_works(self, df, expstart, time_array, time_array_key):
-        ExposureAbsoluteTime(df=df, expstart=expstart, time_array=time_array, time_array_key=time_array_key)
+        with pytest.raises(error):
+            ExposureAbsoluteTime(df=df, expstart=expstart, time_array=time)
+
+    def test_ingest_works(self, good_input):
+        df, expstart, time, time_key = good_input
+        ExposureAbsoluteTime(df=df, expstart=expstart, time_array=time, time_array_key=time_key)
+
+    def test_compute_absolute_time(self, good_input):
+        df, expstart, time, time_key = good_input
+        test_time = ExposureAbsoluteTime(df=df, expstart=expstart, time_array=time, time_array_key=time_key)
+
+        test_time.compute_absolute_time()
+
+    def test_compute_from_df(self, good_input):
+        df, expstart, time, time_key = good_input
+
+        if df is not None:
+            ExposureAbsoluteTime.compute_from_df(df, time_array_key=time_key)
+
+    def test_compute_from_arrays(self, good_input):
+        df, expstart, time, time_key = good_input
+
+        if expstart is not None and time is not None:
+            ExposureAbsoluteTime.compute_from_arrays(expstart=expstart, time_array=time)
 
 
 class TestCreateVisibility:


### PR DESCRIPTION
This PR refactors tests in `test_monitor_helpers` and `test_filesystem` to use fixtures to parametrize tests as well as increases test coverage for both.

Resolves #113 