### PR TITLE
122 add monitor runner

### DIFF
--- a/cosmo/filesystem.py
+++ b/cosmo/filesystem.py
@@ -115,7 +115,11 @@ def get_file_data(fitsfiles: List[str], keywords: Sequence, extensions: Sequence
     @dask.delayed
     def _get_file_data(fitsfile: str, *args, **kwargs) -> Union[FileData, None]:
         """Get specified data from a fitsfile and optionally its corresponding spt file."""
-        return FileData(fitsfile, *args, **kwargs)
+        try:
+            return FileData(fitsfile, *args, **kwargs)
+
+        except ValueError:
+            return
 
     delayed_results = [
         _get_file_data(

--- a/cosmo/monitors/acq_monitors.py
+++ b/cosmo/monitors/acq_monitors.py
@@ -40,6 +40,8 @@ class AcqImageMonitor(BaseMonitor):
     labels = ['ROOTNAME', 'PROPOSID', 'FGS']
     output = COS_MONITORING
 
+    run = 'monthly'
+
     def get_data(self):
         data = select_all_acq(self.model.model, 'ACQ/IMAGE', self.model.new_data)
 
@@ -112,6 +114,8 @@ class AcqImageV2V3Monitor(BaseMonitor):
     subplots = True
     subplot_layout = (2, 1)
     output = COS_MONITORING
+
+    run = 'monthly'
 
     # Define break points for fitting lines; these correspond to important catalogue or FGS dates.
     # TODO Refactor this info into a better, more concise data structure
@@ -415,6 +419,8 @@ class SpecAcqBaseMonitor(BaseMonitor):
     # PEAKD vs PEAKXD need different annotations and shapes
     annotations = None
     shapes = None
+
+    run = 'monthly'
 
     def get_data(self):
         exptype = 'ACQ/PEAKD' if self.slew == 'ACQSLEWX' else 'ACQ/PEAKXD'

--- a/cosmo/monitors/osm_drift_monitors.py
+++ b/cosmo/monitors/osm_drift_monitors.py
@@ -55,6 +55,8 @@ class FUVOSMDriftMonitor(BaseMonitor):
     # [ (1,1)  x1,y1 ]
     # [ (2,1) x2,y2 ]
 
+    run = 'monthly'
+
     def get_data(self):
         return get_osmdrift_data(self.model, 'FUV')
 
@@ -185,6 +187,8 @@ class NUVOSMDriftMonitor(BaseMonitor):
     # This is the format of your plot grid:
     # [ (1,1) x1,y1 ]  [ (1,2) x2,y2 ]
     # [ (2,1) x3,y3 ]  [ (2,2) x4,y4 ]  The axes labels and x/y combinations need to match this layout.
+
+    run = 'monthly'
 
     def get_data(self):
         return get_osmdrift_data(self.model, 'NUV')

--- a/cosmo/monitors/osm_shift_monitors.py
+++ b/cosmo/monitors/osm_shift_monitors.py
@@ -74,7 +74,7 @@ def create_osmshift_buttons(doc_link: str, button_labels: List[str], name: str, 
     ]
 
 
-class FuvOsmShiftMonitor(BaseMonitor):
+class BaseFuvOsmShiftMonitor(BaseMonitor):
     """Abstracted FUV OSM Shift monitor. This monitor class is not meant to be used directly, but rather inherited from
     by specific Shift1 and Shift2 monitors (which share the same plots, but differ in which shift value is plotted and
     how outliers are defined).
@@ -291,25 +291,29 @@ class FuvOsmShiftMonitor(BaseMonitor):
         outliers.to_csv(os.path.join(os.path.dirname(self.output), f'{self._filename}-outliers.csv'))
 
 
-class FuvOsmShift1Monitor(FuvOsmShiftMonitor):
+class FuvOsmShift1Monitor(BaseFuvOsmShiftMonitor):
     """FUV OSM Shift1 (SHIFT_DISP) monitor."""
     shift = 'SHIFT_DISP'  # shift1
+
+    run = 'monthly'
 
     def find_outliers(self):
         """Outliers for shift1 A-B are defined as any difference whose magnitude is greater than 10 pixels."""
         return self.results.seg_diff.abs() > 10
 
 
-class FuvOsmShift2Monitor(FuvOsmShiftMonitor):
+class FuvOsmShift2Monitor(BaseFuvOsmShiftMonitor):
     """FUV OSM Shift2 (SHIFT_XDISP) monitor."""
     shift = 'SHIFT_XDISP'  # shift 2
+
+    run = 'monthly'
 
     def find_outliers(self):
         """Outliers for shift2 A-B are defined as any difference whose magnitude is greater than 5 pixels."""
         return self.results.seg_diff.abs() > 5
 
 
-class NuvOsmShiftMonitor(BaseMonitor):
+class BaseNuvOsmShiftMonitor(BaseMonitor):
     """Abstracted NUV OSM Shift monitor. This monitor class is not meant to be used directly, but rather inherited from
     by specific Shift1 and Shift2 monitors (which share the same plots, but differ in which shift value is plotted and
     how outliers are defined)."""
@@ -518,17 +522,21 @@ class NuvOsmShiftMonitor(BaseMonitor):
         pass
 
 
-class NuvOsmShift1Monitor(NuvOsmShiftMonitor):
+class NuvOsmShift1Monitor(BaseNuvOsmShiftMonitor):
     """NUV OSM Shift1 (SHIFT_DISP) monitor."""
     shift = 'SHIFT_DISP'  # shift1
+
+    run = 'monthly'
 
     def find_outliers(self) -> dict:
         return {'B-C': self.results['B-C'].seg_diff.abs() >= 10, 'C-A': self.results['C-A'].seg_diff.abs() >= 10}
 
 
-class NuvOsmShift2Monitor(NuvOsmShiftMonitor):
+class NuvOsmShift2Monitor(BaseNuvOsmShiftMonitor):
     """NUV OSM Shift2 (SHIFT_XDISP) monitor."""
     shift = 'SHIFT_XDISP'  # shift2
+
+    run = 'monthly'
 
     def find_outliers(self) -> dict:
         return {'B-C': self.results['B-C'].seg_diff.abs() >= 5, 'C-A': self.results['C-A'].seg_diff.abs() >= 5}

--- a/cosmo/pytest.ini
+++ b/cosmo/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+python_files = run_monitors.py
+python_classes = Run*
+python_functions = run_*
+addopts = -rA -v
+markers =
+    monthly: marks monitors that should be run monthly (deselect with '-m "not monthly")
+    ingest: marks a runner that ingests new data only (deselect with '-m "not ingest")

--- a/cosmo/run_monitors.py
+++ b/cosmo/run_monitors.py
@@ -1,0 +1,129 @@
+import os
+import pytest
+import shlex
+
+from argparse import ArgumentParser
+
+from . import monitors
+from .sms import SMSFinder
+
+
+def collection():
+    collection_set = {'monthly': [], 'daily': [], 'all': [], 'datamodels': []}
+
+    for key, value in monitors.__dict__.items():
+        if 'Monitor' in key and 'Base' not in key:
+            collection_set['all'].append(value)
+
+            if 'run' in value.__dict__:
+                collection_set[value.run].append(value)
+
+    # noinspection PyUnresolvedReferences
+    for key, value in monitors.data_models.__dict__.items():
+        if 'DataModel' in key and 'Base' not in key:
+            collection_set['all'].append(value)
+            collection_set['datamodels'].append(value)
+
+    return collection_set
+
+
+COLLECTION = collection()
+
+
+@pytest.fixture
+def monitor():
+    def _monitor(monitor_class):
+        active = monitor_class()
+
+        return active
+
+    return _monitor
+
+
+@pytest.fixture(params=COLLECTION['monthly'])
+def monthly_monitor(request, monitor):
+    """Parametrized fixture for monitors that should be executed monthly."""
+    active = monitor(request.param)
+
+    yield active
+
+    # If run_ingest is not included in the test session, ingest any new data into the databases
+    session_names = [item.name for item in request.session.items]  # names of "test" in the session object
+
+    if 'run_ingest' not in session_names:
+        active.model.ingest()
+
+
+@pytest.fixture(params=COLLECTION['daily'])
+def daily_monitor(request, monitor):
+    active = monitor(request.param)
+
+    yield active
+
+    # If run_ingest is not included in the test session, ingest any new data into the databases
+    session_names = [item.name for item in request.session.items]  # names of "test" in the session object
+
+    if 'run_ingest' not in session_names:
+        active.model.ingest()
+
+
+@pytest.fixture
+def sms():
+    """Fixture for the SMSFinder object."""
+    finder = SMSFinder()
+
+    return finder
+
+
+@pytest.fixture(params=COLLECTION['datamodels'])
+def datamodel(request):
+    """Parametrized fixture for DataModels for use in ingestion only."""
+    active_model = request.param()
+
+    return active_model
+
+
+class RunMonitors:
+    """Class for organizing runners."""
+
+    @pytest.mark.ingest
+    @pytest.mark.monthly
+    def run_sms_ingest(self, sms):
+        """Execute SMS file ingestion. Will be executed before the monthly monitors (since the OSM monitors require that
+         new SMS files be ingested first. Additionally, this runner is included in the "ingest" group.
+         """
+        sms.ingest_files()
+
+    @pytest.mark.ingest
+    def run_ingest(self, datamodel):
+        """Execute DataModel new data discovery and ingestion. Included in the "ingest" group."""
+        datamodel.ingest()
+
+    @pytest.mark.monthly
+    def run_monthly(self, monthly_monitor):
+        """Execute monitors marked as monthly."""
+        monthly_monitor.monitor()
+
+
+def runner():
+    here = os.path.dirname(os.path.abspath(__file__))
+    default_args = f'{here}'
+
+    parser = ArgumentParser()
+
+    parser.add_argument('--monthly', '-mo', action='store_true')
+    parser.add_argument('--ingest', '-in', action='store_true')
+
+    args = parser.parse_args()
+
+    if args.monthly:
+        pytest.main(shlex.split(default_args + ' -m monthly'))
+
+        return
+
+    if args.ingestion:
+        pytest.main(shlex.split(default_args + ' -m ingest'))
+
+        return
+
+    pytest.main(shlex.split(default_args))

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,10 @@ setup(
         'calcos',
         'crds',
         'monitorframe @ git+https://github.com/spacetelescope/monitor-framework#egg=monitorframe'
-    ]
+    ],
+    entry_points={
+        'console_scripts':
+            ['run_monitors=cosmo.run_monitors:runner']
+    },
+    package_data={'cosmo': ['pytest.ini']}
 )


### PR DESCRIPTION
This PR adds a runner for the monitors. 

The "runner" is `pytest`: the idea is to (very) lightly wrap and configure `pytest` to execute the monitors. This includes configuring test discovery, adding a custom "monitor" collector, and including a runner function for convenience and execution from the installed package. Execution of the monitors can also occur via normal `pytest` calls on the `run_monitors` file

Additionally, the monitors were refactored to included a `run` attribute, which is meant to be used with the `collection` function to identify "monthly" and "daily" monitors. If a monitor does not include a "run" attribute, it will not be collected. `collection` also ignores "Base" monitor (and DataModel) classes. 

Lastly, a try/except guard was added to get_file_data. Recently a broken file was encountered, but instead of allowing the monitors to break, I think it'd be best to add logging and document what files were found as corrupted (or otherwise un-openable by `astropy.io.fits`)

Resolves #122 