### PR TITLE
Add runner entrypoint

### DIFF
--- a/cosmo/filesystem.py
+++ b/cosmo/filesystem.py
@@ -79,7 +79,7 @@ class FileData(dict):
             self.get_spt_header_data(spt_file, spt_keywords, spt_extensions)
 
     @staticmethod
-    def _create_spt_filename(filename, spt_suffix) -> Union[str, None]:
+    def _create_spt_filename(filename: str, spt_suffix: str) -> Union[str, None]:
         """Create an spt filename based on the input filename."""
         path, name = os.path.split(filename)
         spt_name = '_'.join([name.split('_')[0], spt_suffix])
@@ -90,7 +90,8 @@ class FileData(dict):
 
         return
 
-    def get_header_data(self, hdu, header_keywords, header_extensions, header_defaults=None):
+    def get_header_data(self, hdu: fits.HDUList, header_keywords: Sequence,
+                        header_extensions: Sequence, header_defaults: dict = None):
         """Get header data."""
         for key, ext in zip(header_keywords, header_extensions):
             if header_defaults is not None and key in header_defaults:
@@ -99,12 +100,12 @@ class FileData(dict):
             else:
                 self.update({key: hdu[ext].header[key]})
 
-    def get_spt_header_data(self, spt_file, spt_keywords, spt_extensions):
+    def get_spt_header_data(self, spt_file: str, spt_keywords: Sequence, spt_extensions: Sequence):
         """Open the spt file and collect requested data."""
         with fits.open(spt_file) as spt:
             self.update({key: spt[ext].header[key] for key, ext in zip(spt_keywords, spt_extensions)})
 
-    def get_table_data(self, hdu, data_keywords, data_extensions):
+    def get_table_data(self, hdu: fits.HDUList, data_keywords: Sequence, data_extensions: Sequence):
         """Get table data."""
         self.update({key: hdu[ext].data[key] for key, ext in zip(data_keywords, data_extensions)})
 
@@ -118,7 +119,7 @@ def get_file_data(fitsfiles: List[str], keywords: Sequence, extensions: Sequence
         try:
             return FileData(fitsfile, *args, **kwargs)
 
-        except ValueError:
+        except (ValueError, OSError):
             return
 
     delayed_results = [

--- a/cosmo/monitor_helpers.py
+++ b/cosmo/monitor_helpers.py
@@ -4,7 +4,7 @@ import datetime
 
 from itertools import repeat
 from astropy.time import Time, TimeDelta
-from typing import Union, Iterable, Tuple, Sequence, List
+from typing import Union, Tuple, Sequence, List
 
 
 def convert_day_of_year(date: Union[float, str]) -> Time:
@@ -14,7 +14,7 @@ def convert_day_of_year(date: Union[float, str]) -> Time:
     return Time(datetime.datetime.strptime(str(date), '%Y.%j'), format='datetime')
 
 
-def fit_line(x: Union[Iterable, Sequence], y: Union[Iterable, Sequence]) -> Tuple[np.poly1d, np.ndarray]:
+def fit_line(x: Sequence, y: Sequence) -> Tuple[np.poly1d, np.ndarray]:
     """Given arrays x and y, fit a line."""
     fit = np.poly1d(np.polyfit(x, y, 1))
 
@@ -38,8 +38,8 @@ def explode_df(df: pd.DataFrame, list_keywords: list) -> pd.DataFrame:
     return exploded
 
 
-def absolute_time(df: pd.DataFrame = None, expstart: Union[Sequence, pd.Series] = None,
-                  time: Union[Sequence, pd.Series] = None, time_key: str = None, time_format: str = 'sec') -> TimeDelta:
+def absolute_time(df: pd.DataFrame = None, expstart: Sequence = None, time: Sequence = None, time_key: str = None,
+                  time_format: str = 'sec') -> TimeDelta:
     """Compute the time sequence relative to the start of the exposure (EXPSTART). Can be computed from a DataFrame that
     contains an EXPSTART column and some other time array column, or from an EXPSTART array and time array pair.
     """
@@ -78,8 +78,7 @@ def create_visibility(trace_lengths: List[int], visible_list: List[bool]) -> Lis
     return visibility
 
 
-def v2v3(slew_x: Union[np.ndarray, pd.Series, list], slew_y: Union[np.ndarray, pd.Series, list]
-         ) -> Tuple[Union[np.ndarray, pd.Series], Union[np.ndarray, pd.Series]]:
+def v2v3(slew_x: Sequence, slew_y: Sequence) -> Tuple[Union[np.ndarray, pd.Series], Union[np.ndarray, pd.Series]]:
     """Detector coordinates to V2/V3 coordinates."""
     # If input are lists, convert to np arrays so that the operations are completed as expected
     if isinstance(slew_x, list):
@@ -98,7 +97,7 @@ def v2v3(slew_x: Union[np.ndarray, pd.Series, list], slew_y: Union[np.ndarray, p
     return v2, v3
 
 
-def get_osm_data(datamodel, detector):
+def get_osm_data(datamodel, detector: str) -> pd.DataFrame:
     """Query for OSM data and append any relevant new data to it."""
     data = pd.DataFrame()
 

--- a/cosmo/run_monitors.py
+++ b/cosmo/run_monitors.py
@@ -126,8 +126,8 @@ def runner():
     # Parse commandline arguments
     parser = ArgumentParser()
 
-    parser.add_argument('--monthly', '-mo', action='store_true')
-    parser.add_argument('--ingest', '-in', action='store_true')
+    parser.add_argument('--monthly', '-mo', action='store_true', help='Execute Monitors marked as "monthly"')
+    parser.add_argument('--ingest', '-in', action='store_true', help='Execute data ingestion for DataModels and SMS')
 
     args = parser.parse_args()
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -118,3 +118,4 @@ Or, they can be executed from the command line::
 For more command line options::
 
     (cosmoenv) mycomputer:~ user$ cosmo --help
+

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -22,7 +22,6 @@ Then install using pip::
     cd cosmo
     pip install .
 
-
 Settings via a Configuration File
 ----------------------------------
 To manage configurations, COSMO uses a ``yaml`` configuration file.
@@ -99,3 +98,23 @@ For executing the tests with coverage (after ``coverage`` has been installed), u
 
     coverage run -m pytest
 
+Executing Monitors
+------------------
+Monitors can be executed by using the monitoring classes directly:
+
+.. code-block:: python
+
+    from cosmo.monitors import AcqImageMonitor
+
+    monitor = AcqImageMonitor()
+
+    # Run it
+    monitor.monitor()
+
+Or, they can be executed from the command line::
+
+    (cosmoenv) mycomputer:~ user$ cosmo --monthly
+
+For more command line options::
+
+    (cosmoenv) mycomputer:~ user$ cosmo --help

--- a/docs/source/monitors.rst
+++ b/docs/source/monitors.rst
@@ -32,6 +32,40 @@ The following monitors are executed at a *monthly* cadence:
 
 .. eventually there will be daily monitors
 
+The Monitor Runner
+------------------
+In order to execute collections of Monitors, COSMO uses ``pytest``.
+
+Collections are determined based on the ``run`` attribute of the Monitor classes, and should reflect the cadence that
+the monitor should be executed with.
+
+Supported cadences:
+
+- ``monthly``
+- ``daily``
+
+By default, all Monitors are also included in an ``all`` collection, which is the default collection if no other options
+are provided.
+
+An ``ingest``  collection is available for executed data ingestion into the Monitor Data database and the
+SMS database independently of executing the Monitors themselves.
+
+When developing COSMO, Monitors can be collected and run via ``pytest`` from the commandline in the typical pytest
+fashion (after cloning the repository into "cosmo"::
+
+    (cosmoenv) mycomputer:cosmo user$ pytest cosmo/run_monitors.py
+
+This basic example will execute all monitors available and attempt to ingest new data into their respective databases.
+
+To execute a collection of monitors (again, from a local "cosmo" repository)::
+
+    (cosmoenv) mycomputer:cosmo user$ pytest cosmo/run_monitors.py -m monthly
+
+COSMO also provides a command line option for executing the monitors without calling ``pytest`` directly, and without
+the need to specify the location of the ``run_monitors`` module::
+
+    (cosmoenv) mycomputer:~ user$ cosmo --monthly
+
 Target Acquisition Monitors
 ---------------------------
 The goal of the Target Acquisition monitors is to assist in cases of failed acquisitions as well as keep track of

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cosmo',
-    version='1.0.0',
+    version='1.0.1',
     description='Monitors for HST/COS',
     keywords=['astronomy'],
     classifiers=[
@@ -18,11 +18,15 @@ setup(
         'astropy>=1.0.1',
         'plotly>=4.0.0',
         'dask',
-        'pandas',
+        'pandas>=0.25.0',
         'pytest',
         'pyyaml',
         'peewee',
         'monitorframe @ git+https://github.com/spacetelescope/monitor-framework#egg=monitorframe'
     ],
-    package_data={'cosmo': ['pytest.ini']}
+    package_data={'cosmo': ['pytest.ini']},
+    entry_points={
+        'console_scripts':
+            ['cosmo=cosmo.run_monitors:runner']
+    }
 )


### PR DESCRIPTION
This PR adds an entry point to the monitor runner so that a console script can be executed to run the monitors. 

Additionally, type hints were added and simplified to the support modules, and the required pandas version was incremented to `0.25.0` or greater