### PR TITLE
160 fix new data bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
         - MONITOR_CONFIG='/home/travis/build/spacetelescope/cosmo/tests/cosmoconfig_test.yaml'
         - COSMO_FILES_SOURCE='/home/travis/build/spacetelescope/cosmo/tests/data'
         - COSMO_SMS_SOURCE='/home/travis/build/spacetelescope/cosmo/tests/data'
+        - COSMO_OUTPUT='/home/travis/build/spacetelescope/cosmo/tests'
         - COSMO_SMS_DB='/home/travis/build/spacetelescope/cosmo/tests/test.db'
         - CRDS_SERVER_URL='https://hst-crds.stsci.edu'
         - CRDS_PATH='/home/travis/build/spacetelescope/cosmo/tests/data/test_crds_cache'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
         - SETUP_CMD='test'
         - COSMO_CONFIG='/home/travis/build/spacetelescope/cosmo/tests/cosmoconfig_test.yaml'
         - MONITOR_CONFIG='/home/travis/build/spacetelescope/cosmo/tests/cosmoconfig_test.yaml'
+        - COSMO_SMS_DB='/home/travis/build/spacetelescope/cosmo/tests/test.db'
         - CRDS_SERVER_URL='https://hst-crds.stsci.edu'
         - CRDS_PATH='/home/travis/build/spacetelescope/cosmo/tests/data/test_crds_cache'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ env:
         - CONDA_DEPS='stsci coverage'
         - CONDA_DOC_DEPS="$CONDA_DEPS sphinx"
         - SETUP_CMD='test'
-        - COSMO_CONFIG='/home/travis/build/spacetelescope/cosmo/tests/cosmoconfig_test.yaml'
         - MONITOR_CONFIG='/home/travis/build/spacetelescope/cosmo/tests/cosmoconfig_test.yaml'
+        - COSMO_FILES_SOURCE='/home/travis/build/spacetelescope/cosmo/tests/data'
+        - COSMO_SMS_SOURCE='/home/travis/build/spacetelescope/cosmo/tests/data'
         - COSMO_SMS_DB='/home/travis/build/spacetelescope/cosmo/tests/test.db'
         - CRDS_SERVER_URL='https://hst-crds.stsci.edu'
         - CRDS_PATH='/home/travis/build/spacetelescope/cosmo/tests/data/test_crds_cache'

--- a/cosmo/__init__.py
+++ b/cosmo/__init__.py
@@ -1,5 +1,18 @@
 import os
-import yaml
 
-with open(os.environ['COSMO_CONFIG']) as yamlfile:
-    SETTINGS = yaml.safe_load(yamlfile)
+SETTINGS = {
+    'filesystem': {'source': os.environ['COSMO_FILES_SOURCE']},
+    'output': os.environ['COSMO_OUTPUT'],
+    'sms': {
+        'source': os.environ['COSMO_SMS_SOURCE'],
+        'db_settings': {
+            'database': os.environ.get('COSMO_SMS_DB', 'sms.db'),
+            'pragmas': {
+                'journal_mode': os.environ.get('COSMO_SMS_DB_JOURNAL', 'wal'),
+                'foreign_keys': os.environ.get('COSMO_SMS_DB_FORIEGN_KEYS', 1),
+                'ignore_check_constraints': os.environ.get('COSMO_SMS_DB_IGNORE_CHECK_CONSTRAINTS', 0),
+                'synchronous': os.environ.get('COSMO_SMS_DB_SYNCHRONOUS', 0)
+            }
+        }
+    },
+}

--- a/cosmo/monitor_helpers.py
+++ b/cosmo/monitor_helpers.py
@@ -123,6 +123,9 @@ def get_osm_data(datamodel, detector: str) -> pd.DataFrame:
             ignore_index=True
         )
 
+    if datamodel.new_data is None:
+        return data
+
     if not datamodel.new_data.empty:
         new_data = datamodel.new_data[datamodel.new_data.DETECTOR == detector].reset_index(drop=True)
         data = data.append(new_data, sort=True, ignore_index=True)

--- a/cosmo/monitors/acq_monitors.py
+++ b/cosmo/monitors/acq_monitors.py
@@ -27,6 +27,9 @@ def select_all_acq(model: Union[Model, None], exptype: str, new_data_df: pd.Data
             ignore_index=True
         )
 
+    if new_data_df is None:
+        return data
+
     if not new_data_df.empty:
         new_data = new_data_df[new_data_df.EXPTYPE == exptype].reset_index(drop=True)
         data = data.append(new_data, sort=True, ignore_index=True)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,7 +17,6 @@ and produce outputs (typically plots).
 
 The examples described below include assumptions about the existing implementation with respect to the configuration
 file.
-For more help with the configuration file, see this section: :ref:`Settings via a Configuration File`
 
 DataModels
 ^^^^^^^^^^

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -26,35 +26,22 @@ The ``-e`` argument is required for users who will also be developing and execut
 
 Configuration
 --------------
-COSMO Settings with a configuration file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To manage configurations, COSMO uses a ``yaml`` configuration file.
-Create a yaml configuration file with the following format:
+COSMO Settings with a ``monitorframe`` Configuration File and Environment Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To manage configurations, COSMO primarily uses environment variables on top of the ``monitorframe`` configuration file.
 
-.. code-block:: yaml
+Use the following, minimum set of environment variables to configure COSMO:
 
-    # Settings for obtaining data from files
-    filesystem:
-      source: ''  # Path to the source files
+.. code-block::
 
-    # Settings for obtaining data from sms files and setting up the sms database
-    sms:
-      source: ''  # This is the path where the sms files exist
-      db_settings:  # These are database keyword arguments
-        database: ''  # Path to sqlite database file
-        pragmas:  # sqlite database connection configurations.
-          journal_mode: 'wal'
-          foreign_keys: 1
-          ignore_check_constraints: 0
-          synchronous: 0
+    COSMO_FILES_SOURCE='path/to/data/files'
+    COSMO_OUTPUT='path/to/monitor/output'
+    COSMO_SMS_SOURCE='path/to/sms/files'
 
-    output: ''
+Additional environment variables are available for further configuring the SMS database and are described in the
+:ref:`sms-database` section.
 
-For more information on sqlite pragma statements, see `this <https://www.sqlite.org/pragma.html>`_.
-
-Once the file is ready, set it as an environment variable, ``COSMO_CONFIG``.
-
-``monitorframe`` also requires a ``yaml`` configuration file with the following:
+``monitorframe`` requires a ``yaml`` configuration file with the following:
 
 .. code-block:: yaml
 
@@ -78,10 +65,9 @@ Once the file is ready, set it as an environment variable, ``COSMO_CONFIG``.
           ignore_check_constraints: 0
           synchronous: 0
 
-This configuration file should be set to an environment variable called ``MONITOR_CONFIG``.
+For more information on sqlite pragma statements, see `this <https://www.sqlite.org/pragma.html>`_.
 
-You can store both of these configurations in one file and have both of the environment variables point to that single
-file.
+This configuration file should be set to an environment variable called ``MONITOR_CONFIG``.
 
 .. warning::
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -107,13 +107,14 @@ Running Tests
 COSMO includes a suite of tests for the package.
 For developers, it's a good idea to execute these tests whenever there are changes to the code or environment.
 
-Before executing tests, set the ``MONITOR_CONFIG`` and ``COSMO_CONFIG`` environment variables to the test configuration
-that's included with the repository: ``cosmo/tests/cosmoconfig_tests.yaml``.
+Before executing tests, set the ``MONITOR_CONFIG`` environment variable to the test configuration
+that's included with the repository: ``cosmo/tests/cosmoconfig_tests.yaml``, and set the ``COSMO_SMS_DB`` environment
+variable to `'test.db'`.
 
 .. note::
 
-    If tests are executed before setting the ``MONITOR_CONFIG`` and ``COSMO_CONFIG`` environment variables to the test
-    configuration file, the tests *will not execute*.
+    If tests are executed before setting the ``MONITOR_CONFIG`` and ``COSMO_SMS_DB`` environment variables to the test
+    configurations, the tests *will not execute*.
 
 If you're in the project directory, you can execute the tests with::
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -20,7 +20,9 @@ After an environment has been prepared, clone the repository::
 Then install using pip::
 
     cd cosmo
-    pip install .
+    pip install -e .
+
+The ``-e`` argument is required for users who will also be developing and execute tests.
 
 Configuration
 --------------

--- a/docs/source/sms.rst
+++ b/docs/source/sms.rst
@@ -27,9 +27,24 @@ change across versions.
 The "largest" version alpha-numerically corresponds to the most up-to-date version of the SMS.
 This is the version that should be used for comparisons with COS data products.
 
+.. _sms-database:
+
 SMS Database
 ------------
-The SMS Database is comprised of two tables, ``SMSFileStats`` and ``SMSTable``.
+Further configuration of the SMS database can be accomplished with the following environment variables (defaults as
+comments):
+
+.. code-block::
+
+    COSMO_SMS_DB  # 'sms.db'
+    COSMO_SMS_DB_JOURNAL  # 'wal'
+    COSMO_SMS_DB_FORIEGN_KEYS  # 1
+    COSMO_SMS_DB_IGNORE_CHECK_CONSTRAINTS  # 0
+    COSMO_SMS_DB_SYNCHRONOUS  # 0
+
+The first item is the path to the database file, while the remaining options are supported pragma statements.
+
+The SMS Database itself is comprised of two tables, ``SMSFileStats`` and ``SMSTable``.
 
 The SMSFileStats table records information about the report files themselves including the SMS ID, Version ID, date of
 ingestion and a "FILEID," which is the combination of the SMS ID and Version ID and is used as a reference in SMSTable.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cosmo',
-    version='1.1.0',
+    version='1.1.1',
     description='Monitors for HST/COS',
     keywords=['astronomy'],
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,15 @@ import pytest
 
 from glob import glob
 
-TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+TEST_CONFIG = os.path.join(HERE, 'cosmoconfig_test.yaml')
 
 # Check to make sure that the test config file is being used. If not, don't run the tests
 if os.environ['MONITOR_CONFIG'] != TEST_CONFIG:
     raise TypeError('Tests should only be executed with the testing configuration file')
 
-if os.environ['COSMO_SMS_DB'] != 'test.db':
+if os.environ['COSMO_SMS_DB'] != os.path.join(HERE, 'test.db'):
     raise TypeError('Test should only be executed with a test database')
 
 
@@ -49,7 +51,7 @@ def data_dir():
 
 @pytest.fixture(scope='session')
 def here():
-    return os.path.dirname(os.path.abspath(__file__))
+    return HERE
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,9 @@ TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmocon
 if os.environ['MONITOR_CONFIG'] != TEST_CONFIG:
     raise TypeError('Tests should only be executed with the testing configuration file')
 
+if os.environ['COSMO_SMS_DB'] != 'test.db':
+    raise TypeError('Test should only be executed with a test database')
+
 
 @pytest.fixture(scope='session', autouse=True)
 def db_cleanup():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from glob import glob
 TEST_CONFIG = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cosmoconfig_test.yaml')
 
 # Check to make sure that the test config file is being used. If not, don't run the tests
-if os.environ['COSMO_CONFIG'] != TEST_CONFIG:
+if os.environ['MONITOR_CONFIG'] != TEST_CONFIG:
     raise TypeError('Tests should only be executed with the testing configuration file')
 
 

--- a/tests/cosmoconfig_test.yaml
+++ b/tests/cosmoconfig_test.yaml
@@ -1,18 +1,3 @@
-filesystem:
-  source: ''
-
-sms:
-  source: ''
-  db_settings:
-    database: 'test.db'
-    pragmas:
-      journal_mode: 'wal'
-      foreign_keys: 1
-      ignore_check_constraints: 0
-      synchronous: 0
-
-output: ''
-
 # Monitor data database
 data:
   db_settings:


### PR DESCRIPTION
This PR fixes the bug where if an `AcqMonitor` or `OSMMonitor` is initialized with `find_new_data=False`, the underlying `DataModel.new_data=None` resulted in an attribute error when the helper functions attempted to join the `new_data` with data recovered from the database.

Additionally, `cosmo` configuration has been cleaned up and streamlined with the `monitorframe` framework utilizing the configuration file for database management, and `cosmo` utilizing environment variables for the remaining handful of options. Documentation has also been updated to include the changes in configuration management. 

Resolves #160 